### PR TITLE
feat(system): GitHub releases for Updates, assembly version, 0.8.5

### DIFF
--- a/backend/Bootstrap/Pipeline/ApiEndpointComposer.cs
+++ b/backend/Bootstrap/Pipeline/ApiEndpointComposer.cs
@@ -17,6 +17,8 @@ internal static class ApiEndpointComposer
 			preloadedUrlBase,
 			englishStringsLazy);
 
+		SystemUpdateEndpoints.Map(api);
+
 		QualityProfileAndConfigEndpoints.Map(api);
 		TagEndpoints.Map(api);
 		CustomFilterEndpoints.Map(api);

--- a/backend/Bootstrap/Pipeline/InitializeEndpoints.cs
+++ b/backend/Bootstrap/Pipeline/InitializeEndpoints.cs
@@ -30,7 +30,7 @@ public static class InitializeEndpoints
 			["urlBase"] = urlBase,
 			["apiRoot"] = apiRoot,
 			["apiKey"] = serverSettings.ApiKey ?? "",
-			["version"] = "0.0.0-dev",
+			["version"] = ApplicationVersion.GetDisplayVersion(),
 			["buildTime"] = "2026-01-01T00:00:00Z",
 			["isDebug"] = true,
 			["isProduction"] = false,

--- a/backend/Features/Settings/Endpoints/SystemUpdateEndpoints.cs
+++ b/backend/Features/Settings/Endpoints/SystemUpdateEndpoints.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Builder;
+
+namespace TubeArr.Backend;
+
+public static class SystemUpdateEndpoints
+{
+	public static void Map(RouteGroupBuilder api)
+	{
+		api.MapGet("/update", async (IHttpClientFactory httpClientFactory, IConfiguration configuration, CancellationToken cancellationToken) =>
+		{
+			try
+			{
+				var items = await RemoteUpdateCatalog.FetchAsync(httpClientFactory, configuration, cancellationToken);
+				return Results.Json(items);
+			}
+			catch
+			{
+				return Results.Json(Array.Empty<UpdateItemDto>());
+			}
+		});
+	}
+}

--- a/backend/Features/Settings/SystemStatusHelpers.cs
+++ b/backend/Features/Settings/SystemStatusHelpers.cs
@@ -26,7 +26,7 @@ internal static class SystemStatusHelpers
 		var sqliteVersion = await QuerySqliteScalarAsync(db, "SELECT sqlite_version();") ?? "";
 		var migrationCount = await QueryMigrationCountAsync(db);
 
-		var version = ReadInformationalVersion();
+		var version = ApplicationVersion.GetDisplayVersion();
 		var buildTime = ReadAssemblyBuildTimeUtc();
 
 		var startTimeUtc = TimeZoneInfo.ConvertTimeToUtc(Process.GetCurrentProcess().StartTime);
@@ -177,25 +177,6 @@ internal static class SystemStatusHelpers
 		{
 			return 0;
 		}
-	}
-
-	static string ReadInformationalVersion()
-	{
-		var asm = Assembly.GetExecutingAssembly();
-		var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-		if (!string.IsNullOrWhiteSpace(info))
-		{
-			var plus = info.IndexOf('+', StringComparison.Ordinal);
-			return plus > 0 ? info[..plus] : info;
-		}
-
-		var v = asm.GetName().Version;
-		if (v is null || (v.Major == 0 && v.Minor == 0 && v.Build == 0 && v.Revision == 0))
-		{
-			return "0.0.0-dev";
-		}
-
-		return v.ToString();
 	}
 
 	static string ReadAssemblyBuildTimeUtc()

--- a/backend/Shared/Helpers/ApplicationUpdateChecker.cs
+++ b/backend/Shared/Helpers/ApplicationUpdateChecker.cs
@@ -1,5 +1,4 @@
 using System.Net.Http.Headers;
-using System.Reflection;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -24,11 +23,9 @@ internal static class ApplicationUpdateChecker
 
 		var url = (configuration["TubeArr:UpdateCheckUrl"] ?? "").Trim();
 		if (string.IsNullOrWhiteSpace(url))
-		{
-			return (true, "No update check URL configured. Set TubeArr:UpdateCheckUrl (e.g. GitHub releases API JSON) to enable.");
-		}
+			url = RemoteUpdateCatalog.DefaultGitHubReleasesUrl;
 
-		var current = GetCurrentVersionLabel();
+		var current = ApplicationVersion.GetDisplayVersion();
 
 		try
 		{
@@ -45,6 +42,9 @@ internal static class ApplicationUpdateChecker
 			var json = await response.Content.ReadAsStringAsync(ct);
 			using var doc = JsonDocument.Parse(json);
 			var root = doc.RootElement;
+			if (root.ValueKind == JsonValueKind.Array && root.GetArrayLength() > 0)
+				root = root[0];
+
 			string? remote = null;
 			if (root.TryGetProperty("tag_name", out var tagEl) && tagEl.ValueKind == JsonValueKind.String)
 				remote = tagEl.GetString();
@@ -60,15 +60,5 @@ internal static class ApplicationUpdateChecker
 		{
 			return (false, "Update check failed: " + (ex.Message ?? "Unknown error"));
 		}
-	}
-
-	static string GetCurrentVersionLabel()
-	{
-		var asm = Assembly.GetExecutingAssembly();
-		var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-		if (!string.IsNullOrWhiteSpace(info))
-			return info!;
-		var v = asm.GetName().Version;
-		return v is null ? "unknown" : v.ToString();
 	}
 }

--- a/backend/Shared/Helpers/ApplicationVersion.cs
+++ b/backend/Shared/Helpers/ApplicationVersion.cs
@@ -1,0 +1,24 @@
+using System.Reflection;
+
+namespace TubeArr.Backend;
+
+/// <summary>Resolved app version for UI, API, and update checks (matches SDK / informational version rules).</summary>
+public static class ApplicationVersion
+{
+	public static string GetDisplayVersion()
+	{
+		var asm = Assembly.GetExecutingAssembly();
+		var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+		if (!string.IsNullOrWhiteSpace(info))
+		{
+			var plus = info.IndexOf('+', StringComparison.Ordinal);
+			return plus > 0 ? info[..plus] : info;
+		}
+
+		var v = asm.GetName().Version;
+		if (v is null || (v.Major == 0 && v.Minor == 0 && v.Build == 0 && v.Revision == 0))
+			return "0.0.0-dev";
+
+		return v.ToString();
+	}
+}

--- a/backend/Shared/Helpers/RemoteUpdateCatalog.cs
+++ b/backend/Shared/Helpers/RemoteUpdateCatalog.cs
@@ -1,0 +1,129 @@
+using System.Text.Json;
+
+namespace TubeArr.Backend;
+
+/// <summary>Fetches remote application releases (GitHub Releases API) for System → Updates.</summary>
+internal static class RemoteUpdateCatalog
+{
+	internal const string DefaultGitHubReleasesUrl = "https://api.github.com/repos/tubearrteam/TubeArr/releases?per_page=20";
+
+	public static async Task<IReadOnlyList<UpdateItemDto>> FetchAsync(
+		IHttpClientFactory httpClientFactory,
+		IConfiguration configuration,
+		CancellationToken cancellationToken)
+	{
+		var url = (configuration["TubeArr:UpdateCheckUrl"] ?? "").Trim();
+		if (string.IsNullOrEmpty(url))
+			url = DefaultGitHubReleasesUrl;
+
+		var client = url.Contains("api.github.com", StringComparison.OrdinalIgnoreCase)
+			? httpClientFactory.CreateClient("GitHub")
+			: httpClientFactory.CreateClient();
+
+		using var response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+		if (!response.IsSuccessStatusCode)
+			return Array.Empty<UpdateItemDto>();
+
+		await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+		using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+		if (doc.RootElement.ValueKind != JsonValueKind.Array)
+			return Array.Empty<UpdateItemDto>();
+
+		var current = ApplicationVersion.GetDisplayVersion();
+		var currentNorm = NormalizeCurrentLabel(current);
+		var rows = new List<(Version Ver, string Normalized, JsonElement El)>();
+		foreach (var el in doc.RootElement.EnumerateArray())
+		{
+			if (!el.TryGetProperty("tag_name", out var tagProp))
+				continue;
+			var tag = tagProp.GetString();
+			if (!TryParseReleaseVersion(tag, out var normalized, out var ver))
+				continue;
+			rows.Add((ver, normalized, el));
+		}
+
+		rows.Sort(static (a, b) => b.Ver.CompareTo(a.Ver));
+
+		var items = new List<UpdateItemDto>(rows.Count);
+		for (var i = 0; i < rows.Count; i++)
+		{
+			var (_, normalized, el) = rows[i];
+			DateTimeOffset published = DateTimeOffset.MinValue;
+			if (el.TryGetProperty("published_at", out var p) && DateTimeOffset.TryParse(p.GetString(), out var dto))
+				published = dto;
+
+			var body = el.TryGetProperty("body", out var b) ? b.GetString() ?? "" : "";
+			var htmlUrl = el.TryGetProperty("html_url", out var h) ? h.GetString() ?? "" : "";
+
+			var installed = currentNorm is not null
+				&& string.Equals(normalized, currentNorm, StringComparison.OrdinalIgnoreCase);
+
+			items.Add(new UpdateItemDto(
+				Id: i + 1,
+				Version: normalized,
+				Branch: "main",
+				ReleaseDate: published.ToString("O"),
+				FileName: "",
+				Url: htmlUrl,
+				Installed: installed,
+				InstalledOn: "",
+				Installable: false,
+				Latest: i == 0,
+				Changes: string.IsNullOrWhiteSpace(body)
+					? null
+					: new UpdateChangesDto(new[] { body.Trim() }, Array.Empty<string>()),
+				Hash: ""));
+		}
+
+		return items;
+	}
+
+	internal static bool TryParseReleaseVersion(string? tag, out string normalized, out Version version)
+	{
+		normalized = "";
+		version = new Version(0, 0);
+		if (string.IsNullOrWhiteSpace(tag))
+			return false;
+
+		var s = tag.Trim();
+		if (s.StartsWith('v') || s.StartsWith('V'))
+			s = s[1..];
+
+		// Trim prerelease suffix for System.Version (e.g. 1.2.3-beta1 → 1.2.3)
+		var dash = s.IndexOf('-', StringComparison.Ordinal);
+		if (dash > 0)
+			s = s[..dash];
+
+		if (!Version.TryParse(s, out var parsed))
+			return false;
+
+		version = parsed;
+		normalized = $"{parsed.Major}.{parsed.Minor}.{parsed.Build}";
+		return true;
+	}
+
+	static string? NormalizeCurrentLabel(string? current)
+	{
+		if (!TryParseReleaseVersion(current, out var norm, out _))
+			return null;
+		return norm;
+	}
+}
+
+internal sealed record UpdateChangesDto(
+	[property: System.Text.Json.Serialization.JsonPropertyName("new")] string[] New,
+	[property: System.Text.Json.Serialization.JsonPropertyName("fixed")] string[] Fixed);
+
+internal sealed record UpdateItemDto(
+	int Id,
+	string Version,
+	string Branch,
+	string ReleaseDate,
+	string FileName,
+	string Url,
+	bool Installed,
+	string InstalledOn,
+	bool Installable,
+	bool Latest,
+	UpdateChangesDto? Changes,
+	string Hash);

--- a/backend/Shared/Localization/en.json
+++ b/backend/Shared/Localization/en.json
@@ -2105,6 +2105,7 @@
     "UpdatePath":  "Update Path",
     "UpdaterLogFiles":  "Updater Log Files",
     "Updates":  "Updates",
+    "ViewReleasePage":  "View release on GitHub",
     "UpdateScriptPathHelpText":  "Path to a custom script that takes an extracted update package and handle the remainder of the update process",
     "UpdateSelected":  "Update Selected",
     "UpdateStartupNotWritableHealthCheckMessage":  "Cannot install update because startup folder \u0027{startupFolder}\u0027 is not writable by the user \u0027{userName}\u0027.",

--- a/backend/TubeArr.Backend.Tests/EndpointCompositionSmokeTests.cs
+++ b/backend/TubeArr.Backend.Tests/EndpointCompositionSmokeTests.cs
@@ -33,6 +33,7 @@ public sealed class EndpointCompositionSmokeTests
 			var client = app.GetTestClient();
 
 			await AssertStatusAsync(client, "/initialize.json", HttpStatusCode.OK);
+			await AssertStatusAsync(client, "/api/v1/update", HttpStatusCode.OK);
 			await AssertStatusAsync(client, "/api/v1/command", HttpStatusCode.OK);
 			await AssertStatusAsync(client, "/api/v1/channels", HttpStatusCode.OK);
 			await AssertStatusAsync(client, "/api/v1/queue/status", HttpStatusCode.OK);

--- a/backend/TubeArr.Backend.Tests/RemoteUpdateCatalogTests.cs
+++ b/backend/TubeArr.Backend.Tests/RemoteUpdateCatalogTests.cs
@@ -1,0 +1,24 @@
+using Xunit;
+using TubeArr.Backend;
+
+namespace TubeArr.Backend.Tests;
+
+public class RemoteUpdateCatalogTests
+{
+	[Theory]
+	[InlineData("v0.8.5", "0.8.5")]
+	[InlineData("0.8.5", "0.8.5")]
+	[InlineData("V1.2.3", "1.2.3")]
+	public void TryParseReleaseVersion_normalizes_tags(string tag, string expected)
+	{
+		Assert.True(RemoteUpdateCatalog.TryParseReleaseVersion(tag, out var norm, out _));
+		Assert.Equal(expected, norm);
+	}
+
+	[Fact]
+	public void TryParseReleaseVersion_rejects_prerelease_noise_after_strip()
+	{
+		Assert.True(RemoteUpdateCatalog.TryParseReleaseVersion("1.0.0-rc1", out var norm, out _));
+		Assert.Equal("1.0.0", norm);
+	}
+}

--- a/backend/TubeArr.Backend.csproj
+++ b/backend/TubeArr.Backend.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Version>0.8.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -15,7 +15,7 @@
   },
   "AllowedHosts": "*",
   "TubeArr": {
-    "UpdateCheckUrl": "",
+    "UpdateCheckUrl": "https://api.github.com/repos/tubearrteam/TubeArr/releases?per_page=20",
     "DownloadHistoryRetentionDays": 90
   }
 }

--- a/docs/frontend-click-qa-checklist.md
+++ b/docs/frontend-click-qa-checklist.md
@@ -147,7 +147,7 @@ Complete one pass per area; use real data where needed.
 
 - [ ] **Backup** ([`BackupsConnector`](../frontend/src/System/Backup/BackupsConnector.js)): restore or download on a sample row (non-destructive test environment)
 - [ ] **Tasks**: run or inspect a scheduled/queued task control
-- [ ] **Updates**: check for updates control
+- [ ] **Updates**: list loads from `/api/v1/update`; per-release **View release on GitHub** opens in a new tab (when a release exists)
 - [ ] **Events**: open row details modal if available
 
 ### Activity hub ([`ActivityPage.tsx`](../frontend/src/Activity/ActivityPage.tsx))

--- a/frontend/src/System/Updates/Updates.css
+++ b/frontend/src/System/Updates/Updates.css
@@ -51,3 +51,11 @@
   margin-left: 10px;
   font-size: 14px;
 }
+
+.releaseLinkRow {
+  margin-bottom: 10px;
+}
+
+.releaseLink {
+  font-size: 14px;
+}

--- a/frontend/src/System/Updates/Updates.tsx
+++ b/frontend/src/System/Updates/Updates.tsx
@@ -28,6 +28,26 @@ import styles from './Updates.css';
 
 const VERSION_REGEX = /\d+\.\d+\.\d+\.\d+/i;
 
+function parseSemverParts(label: string): [number, number, number] {
+  const m = label.replace(/^v/i, '').match(/(\d+)\.(\d+)\.(\d+)/u);
+  if (!m) {
+    return [0, 0, 0];
+  }
+  return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10)];
+}
+
+function compareSemver(a: string, b: string): number {
+  const pa = parseSemverParts(a);
+  const pb = parseSemverParts(b);
+  for (let i = 0; i < 3; i++) {
+    const d = pa[i] - pb[i];
+    if (d !== 0) {
+      return d;
+    }
+  }
+  return 0;
+}
+
 function createUpdatesSelector() {
   return createSelector(
     (state: AppState) => state.system.updates,
@@ -84,7 +104,7 @@ function Updates() {
     docker: translate('DockerUpdater'),
   };
 
-  const { isMajorUpdate, hasUpdateToInstall } = useMemo(() => {
+  const { isMajorUpdate, hasUpdateToInstall, isUpToDateWithCatalog } = useMemo(() => {
     const majorVersion = parseInt(
       currentVersion.match(VERSION_REGEX)?.[0] ?? '0'
     );
@@ -94,15 +114,22 @@ function Updates() {
       latestVersion?.match(VERSION_REGEX)?.[0] ?? '0'
     );
 
+    const isUpToDate =
+      !items.length ||
+      (latestVersion != null &&
+        compareSemver(currentVersion, latestVersion) >= 0);
+
     return {
       isMajorUpdate: latestMajorVersion > majorVersion,
       hasUpdateToInstall: items.some(
         (update) => update.installable && update.latest
       ),
+      isUpToDateWithCatalog: isUpToDate,
     };
   }, [currentVersion, items]);
 
-  const noUpdateToInstall = hasUpdates && !hasUpdateToInstall;
+  const noUpdateToInstall =
+    hasUpdates && !hasUpdateToInstall && isUpToDateWithCatalog;
 
   const handleInstallLatestPress = useCallback(() => {
     if (isMajorUpdate) {
@@ -240,6 +267,19 @@ function Updates() {
                       </Label>
                     ) : null}
                   </div>
+
+                  {update.url ? (
+                    <div className={styles.releaseLinkRow}>
+                      <a
+                        className={styles.releaseLink}
+                        href={update.url}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                      >
+                        {translate('ViewReleasePage')}
+                      </a>
+                    </div>
+                  ) : null}
 
                   {update.changes ? (
                     <div>


### PR DESCRIPTION
- Add GET /api/v1/update and RemoteUpdateCatalog (GitHub Releases API); default TubeArr:UpdateCheckUrl
- ApplicationVersion.GetDisplayVersion() for initialize.json and system status; bump Version to 0.8.5
- ApplicationUpdateChecker: default GitHub URL; parse releases array
- Updates UI: semver compare for on-latest banner; link to release (View release on GitHub)
- Tests and QA checklist

## Summary by Sourcery

Integrate GitHub Releases–backed update catalog and unified version reporting across API, UI, and update checks.

New Features:
- Expose /api/v1/update endpoint backed by a remote update catalog using the GitHub Releases API and configurable TubeArr:UpdateCheckUrl.
- Show per-release "View release on GitHub" links in the System → Updates UI when a release URL is available.

Enhancements:
- Use a centralized ApplicationVersion helper for display and update-check version strings, and surface this version in initialize.json and system status responses.
- Default the update check configuration to the TubeArr GitHub releases URL and adjust frontend logic to semver-compare versions for the on-latest banner.

Documentation:
- Expand the frontend QA checklist to cover loading updates from /api/v1/update and validating the GitHub release link behavior.

Tests:
- Add smoke coverage for the new /api/v1/update endpoint and unit tests for RemoteUpdateCatalog release tag parsing.