### PR TITLE
Apply bundled yt-dlp path in Docker (startup bootstrap)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ VOLUME ["/config", "/downloads"]
 EXPOSE 5075
 ENV ASPNETCORE_URLS=http://+:5075
 ENV TubeArr__BundledFfmpegPath=/usr/bin/ffmpeg
+ENV TubeArr__BundledYtDlpPath=/usr/local/bin/yt-dlp
 
 USER tubearr
 

--- a/backend/Bootstrap/Startup/DatabaseBootstrap.cs
+++ b/backend/Bootstrap/Startup/DatabaseBootstrap.cs
@@ -23,6 +23,7 @@ internal static class DatabaseBootstrap
 
 		var configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
 		TryApplyBundledFfmpegPath(db, configuration, logger);
+		TryApplyBundledYtDlpPath(db, configuration, logger);
 
 		TryRepairSqliteYtDlpConfigDownloadQueueParallelWorkers(db, logger);
 
@@ -146,6 +147,56 @@ internal static class DatabaseBootstrap
 		db.SaveChanges();
 		logger.LogInformation(
 			"FFmpeg executable path set to bundled default '{BundledPath}' (Enabled={Enabled}).",
+			bundled,
+			enabledAfter);
+	}
+
+	/// <summary>
+	/// When <c>TubeArr:BundledYtDlpPath</c> is set (e.g. Docker <c>ENV TubeArr__BundledYtDlpPath=/usr/local/bin/yt-dlp</c>),
+	/// use it if yt-dlp is not configured or the saved path no longer exists.
+	/// Uses the single application row <see cref="YtDlpConfigEntity"/> with <c>Id = 1</c>, matching API get-or-create behavior.
+	/// </summary>
+	static void TryApplyBundledYtDlpPath(TubeArrDbContext db, IConfiguration configuration, ILogger logger)
+	{
+		var bundled = configuration["TubeArr:BundledYtDlpPath"]?.Trim();
+		if (string.IsNullOrEmpty(bundled))
+			return;
+
+		if (!File.Exists(bundled))
+		{
+			logger.LogWarning(
+				"TubeArr:BundledYtDlpPath is set to '{BundledPath}' but that file does not exist; skipping bundled yt-dlp bootstrap.",
+				bundled);
+			return;
+		}
+
+		const int ytDlpConfigId = 1;
+		var row = db.YtDlpConfig.Find(ytDlpConfigId);
+		var current = (row?.ExecutablePath ?? "").Trim();
+		if (!string.IsNullOrEmpty(current) && File.Exists(current))
+			return;
+
+		bool enabledAfter;
+		if (row is null)
+		{
+			row = new YtDlpConfigEntity
+			{
+				Id = ytDlpConfigId,
+				ExecutablePath = bundled,
+				Enabled = true
+			};
+			db.YtDlpConfig.Add(row);
+			enabledAfter = row.Enabled;
+		}
+		else
+		{
+			row.ExecutablePath = bundled;
+			enabledAfter = row.Enabled;
+		}
+
+		db.SaveChanges();
+		logger.LogInformation(
+			"yt-dlp executable path set to bundled default '{BundledPath}' (Enabled={Enabled}).",
 			bundled,
 			enabledAfter);
 	}

--- a/backend/Persistence/Entities/YtDlpConfigEntity.cs
+++ b/backend/Persistence/Entities/YtDlpConfigEntity.cs
@@ -1,5 +1,6 @@
 namespace TubeArr.Backend.Data;
 
+/// <summary>yt-dlp tool settings. The application uses a single logical row with <c>Id = 1</c> (see API get-or-create).</summary>
 public sealed class YtDlpConfigEntity
 {
 	public int Id { get; set; } = 1;

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -29,6 +29,7 @@
   "AllowedHosts": "*",
   "TubeArr": {
     "BundledFfmpegPath": "",
+    "BundledYtDlpPath": "",
     "UpdateCheckUrl": "https://api.github.com/repos/tubearrteam/TubeArr/releases?per_page=20",
     "DownloadHistoryRetentionDays": 90,
     "Features": {


### PR DESCRIPTION
Adds \TubeArr__BundledYtDlpPath=/usr/local/bin/yt-dlp\ to the runtime image and \TryApplyBundledYtDlpPath\ in database bootstrap, matching the existing FFmpeg flow: warn when the configured bundled path is missing, only replace empty or missing saved paths, preserve \Enabled\ on existing rows, and document the single-row \Id = 1\ convention on \YtDlpConfigEntity\.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Apply a bundled yt-dlp executable path during startup to mirror the existing FFmpeg bootstrap behavior and document the single-row yt-dlp config convention.

New Features:
- Support configuring a bundled yt-dlp executable path via configuration and Docker environment for automatic startup initialization.

Enhancements:
- Add startup bootstrap logic to populate or repair the yt-dlp executable path from the bundled default when no valid path is stored, preserving the existing enabled state.
- Document that yt-dlp configuration is represented by a single logical row with Id = 1 in the yt-dlp config entity.

Build:
- Set the Docker runtime image to expose a default bundled yt-dlp path environment variable alongside the existing FFmpeg path.