### PR TITLE
Apply bundled yt-dlp path in Docker startup bootstrap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ VOLUME ["/config", "/downloads"]
 EXPOSE 5075
 ENV ASPNETCORE_URLS=http://+:5075
 ENV TubeArr__BundledFfmpegPath=/usr/bin/ffmpeg
+ENV TubeArr__BundledYtDlpPath=/usr/local/bin/yt-dlp
 
 USER tubearr
 

--- a/backend/Bootstrap/Startup/DatabaseBootstrap.cs
+++ b/backend/Bootstrap/Startup/DatabaseBootstrap.cs
@@ -23,6 +23,7 @@ internal static class DatabaseBootstrap
 
 		var configuration = scope.ServiceProvider.GetRequiredService<IConfiguration>();
 		TryApplyBundledFfmpegPath(db, configuration, logger);
+		TryApplyBundledYtDlpPath(db, configuration, logger);
 
 		TryRepairSqliteYtDlpConfigDownloadQueueParallelWorkers(db, logger);
 
@@ -146,6 +147,56 @@ internal static class DatabaseBootstrap
 		db.SaveChanges();
 		logger.LogInformation(
 			"FFmpeg executable path set to bundled default '{BundledPath}' (Enabled={Enabled}).",
+			bundled,
+			enabledAfter);
+	}
+
+	/// <summary>
+	/// When <c>TubeArr:BundledYtDlpPath</c> is set (e.g. Docker <c>ENV TubeArr__BundledYtDlpPath=/usr/local/bin/yt-dlp</c>),
+	/// use it if yt-dlp is not configured or the saved path no longer exists.
+	/// Uses the single application row <see cref="YtDlpConfigEntity"/> with <c>Id = 1</c>, matching API get-or-create behavior.
+	/// </summary>
+	static void TryApplyBundledYtDlpPath(TubeArrDbContext db, IConfiguration configuration, ILogger logger)
+	{
+		var bundled = configuration["TubeArr:BundledYtDlpPath"]?.Trim();
+		if (string.IsNullOrEmpty(bundled))
+			return;
+
+		if (!File.Exists(bundled))
+		{
+			logger.LogWarning(
+				"TubeArr:BundledYtDlpPath is set to '{BundledPath}' but that file does not exist; skipping bundled yt-dlp bootstrap.",
+				bundled);
+			return;
+		}
+
+		const int ytDlpConfigId = 1;
+		var row = db.YtDlpConfig.Find(ytDlpConfigId);
+		var current = (row?.ExecutablePath ?? "").Trim();
+		if (!string.IsNullOrEmpty(current) && File.Exists(current))
+			return;
+
+		bool enabledAfter;
+		if (row is null)
+		{
+			row = new YtDlpConfigEntity
+			{
+				Id = ytDlpConfigId,
+				ExecutablePath = bundled,
+				Enabled = true
+			};
+			db.YtDlpConfig.Add(row);
+			enabledAfter = row.Enabled;
+		}
+		else
+		{
+			row.ExecutablePath = bundled;
+			enabledAfter = row.Enabled;
+		}
+
+		db.SaveChanges();
+		logger.LogInformation(
+			"yt-dlp executable path set to bundled default '{BundledPath}' (Enabled={Enabled}).",
 			bundled,
 			enabledAfter);
 	}

--- a/backend/Persistence/Entities/YtDlpConfigEntity.cs
+++ b/backend/Persistence/Entities/YtDlpConfigEntity.cs
@@ -1,5 +1,6 @@
 namespace TubeArr.Backend.Data;
 
+/// <summary>yt-dlp tool settings. The application uses a single logical row with <c>Id = 1</c> (see API get-or-create).</summary>
 public sealed class YtDlpConfigEntity
 {
 	public int Id { get; set; } = 1;

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -29,6 +29,7 @@
   "AllowedHosts": "*",
   "TubeArr": {
     "BundledFfmpegPath": "",
+    "BundledYtDlpPath": "",
     "UpdateCheckUrl": "https://api.github.com/repos/tubearrteam/TubeArr/releases?per_page=20",
     "DownloadHistoryRetentionDays": 90,
     "Features": {


### PR DESCRIPTION
This pull request adds support for configuring a default bundled path for the `yt-dlp` executable, similar to how the application already handles `ffmpeg`. This allows the application to automatically use a provided `yt-dlp` binary (such as one included in the Docker image) if no other path is configured or the previous one is missing. The changes ensure that the path is set in both the Docker environment and application configuration, and they update the database bootstrap logic to apply the bundled path as needed.

**Bundled yt-dlp path support:**

* Added a new environment variable `TubeArr__BundledYtDlpPath` in the `Dockerfile` to specify the location of the `yt-dlp` binary when running in Docker.
* Updated `appsettings.json` to include a `BundledYtDlpPath` setting for configuration outside of Docker.
* Implemented the `TryApplyBundledYtDlpPath` method in `DatabaseBootstrap.cs`, which sets the `yt-dlp` path in the database if not already configured or if the saved path is missing.
* Updated the database initialization sequence to call `TryApplyBundledYtDlpPath`, ensuring the bundled path is applied during startup.

**Code documentation and structure:**

* Added a summary comment to `YtDlpConfigEntity` clarifying its purpose and usage of a single logical row with `Id = 1`.

## Summary by Sourcery

Apply a configurable bundled yt-dlp executable path during database startup, mirroring existing ffmpeg handling and wiring it into Docker and default configuration.

New Features:
- Introduce support for a bundled yt-dlp executable path that is automatically applied to the yt-dlp configuration when no valid path is set.

Enhancements:
- Extend database bootstrap to initialize or update the yt-dlp configuration row using the bundled path when appropriate.
- Document the purpose and usage pattern of the YtDlpConfigEntity as a single logical configuration row.

Build:
- Set a default TubeArr__BundledYtDlpPath environment variable in the Dockerfile to point to the bundled yt-dlp binary.