### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+TubeArr is a self-hosted YouTube channel manager (Sonarr/Radarr style). Single repo with an ASP.NET Core 8 backend (C#) and a React 19 + TypeScript frontend built with Webpack 5. SQLite database (embedded, auto-created). See `README.md` for full feature list.
+
+### Prerequisites
+
+- **.NET 8 SDK** — backend build/run/test
+- **Node.js 24** (per `.nvmrc`) — frontend build and dev tooling
+- **npm** with `legacy-peer-deps=true` (already set in `.npmrc`)
+
+### Running the dev environment
+
+Two-process dev mode (hot reload on both sides):
+
+```bash
+# Terminal 1 — Backend API on port 5075
+npm run dev:backend
+
+# Terminal 2 — Webpack dev server on port 3000 (proxies /api and /signalr to backend)
+npm run dev:frontend
+```
+
+Access the app at `http://localhost:3000` during development. The backend alone at `http://localhost:5075` serves the last production build from `_output/UI/`.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install && dotnet restore TubeArr.sln` |
+| Build frontend | `npm run build:frontend` |
+| Build backend | `dotnet build backend/TubeArr.Backend.csproj` |
+| Run tests | `npm test` |
+| Dev backend | `npm run dev:backend` |
+| Dev frontend | `npm run dev:frontend` |
+
+### Test notes
+
+- `npm test` runs `dotnet test` on the xUnit test project (backend/TubeArr.Backend.Tests).
+- 4 tests fail on Linux by design: 3 are Windows-path parsing tests (`PlexFilenameParserTests.show_folder_name_from_path` with `D:\` paths) and 1 requires yt-dlp installed (`YtDlpCookiesPathResolverTests`). These are pre-existing platform-specific failures.
+- There are no frontend-specific test commands.
+
+### Gotchas
+
+- Node.js must be v24+ (`.nvmrc` says `24`). If using nvm: `nvm use 24`.
+- `.npmrc` sets `legacy-peer-deps=true` — do not remove this, peer dep resolution will fail without it.
+- The SQLite DB is auto-created at `backend/TubeArr.dev.db` in dev mode. No migrations command needed — EF Core runs them on startup.
+- `yt-dlp` and `ffmpeg` are optional for UI/API development. They are only needed for actual video downloading. System Status page will show health warnings without them.
+- The webpack dev server proxies `/api` and `/signalr` to the backend at `http://localhost:5075` (configurable via `TUBEARR_BACKEND_URL` env var).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents, covering:

- Project overview and prerequisites (.NET 8 SDK, Node.js 24, npm)
- Dev environment commands (two-process hot-reload setup)
- Key commands table (install, build, test, dev)
- Test notes (4 known platform-specific failures on Linux)
- Gotchas (nvm, legacy-peer-deps, SQLite auto-creation, yt-dlp/ffmpeg optional, webpack proxy config)

### Verification

[tubearr-full-walkthrough-demo.mp4](https://cursor.com/agents/bc-4f70065c-41a1-4fc8-817a-76155e55c1b5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftubearr-full-walkthrough-demo.mp4)

Full walkthrough: channels list, channel detail (Rick Astley added), settings, YouTube config, system status, and activity pages.

[Channels list with Rick Astley](https://cursor.com/agents/bc-4f70065c-41a1-4fc8-817a-76155e55c1b5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F06-channels-list-with-rick-astley.webp)
[System status](https://cursor.com/agents/bc-4f70065c-41a1-4fc8-817a-76155e55c1b5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F09-system-status.webp)

**Testing performed:**
- `npm test` — 231/235 passed (4 pre-existing platform-specific failures)
- `npm run build:frontend` — webpack compiled successfully
- `npm run dev:backend` — backend API on port 5075
- `npm run dev:frontend` — webpack dev server on port 3000 with proxy
- Added Rick Astley channel via UI to verify end-to-end functionality

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f70065c-41a1-4fc8-817a-76155e55c1b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f70065c-41a1-4fc8-817a-76155e55c1b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Add developer-facing documentation for setting up and running the Cursor Cloud agent development environment.

Documentation:
- Document project overview, tech stack, and environment prerequisites for TubeArr agents in AGENTS.md.
- Describe standard dev workflow, including backend/frontend hot-reload setup and key npm/dotnet commands.
- Record known Linux-specific test failures and outline expected behavior for platform-dependent tests.
- Highlight common development gotchas, including Node/nvm constraints, SQLite auto-creation, optional yt-dlp/ffmpeg, and webpack proxy configuration.